### PR TITLE
Allow graph_variable to be changed when creating Client

### DIFF
--- a/gremlin_rest/client.py
+++ b/gremlin_rest/client.py
@@ -64,13 +64,14 @@ class ExecutableGremlin(Gremlin):
 
 
 class GremlinClient(ClientBase):
-    def __init__(self, base_url, async = False):
+    def __init__(self, base_url, async = False, graph_variable = 'graph'):
         super(GremlinClient, self).__init__(base_url,
                                             add_headers = { 'Content-Type' : 'application/json; charset=utf-8' },
                                             async = async)
         self.scripts = {}
         self.wrapper_mapping = WrapperMapping(self)
         self.refresh_scripts(os.path.join(os.path.dirname(__file__), 'scripts'))
+        self.graph_variable = graph_variable
 
     def __getattr__(self, script_name):
         assert script_name in self.scripts, 'Trying to call unknown script %s' % script_name
@@ -80,7 +81,7 @@ class GremlinClient(ClientBase):
         self.wrapper_mapping.register_wrapper(type, label, func)
 
     def gremlin(self):
-        return ExecutableGremlin(self, graph_variable = 'graph')
+        return ExecutableGremlin(self, graph_variable = self.graph_variable)
 
     def V(self, arg = None):
         if not arg is None:


### PR DESCRIPTION
I get errors when trying to use your ligrary. This PR fixes them when I specify `graph_variable = "g"` (instead of default `graph`)

```
>>> from gremlin_rest import GremlinClient
>>> client = GremlinClient('http://gremlin:8182')
>>> client.gremlin().V().count().run()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/gremlin_rest/client.py", line 63, in run
    return self.client.run_script(str(self), **self.bound_params)
  File "/usr/lib/python2.7/site-packages/gremlin_rest/client.py", line 115, in run_script
    script_code_or_name)
  File "/usr/lib/python2.7/site-packages/pyarc/base.py", line 104, in post
    return self.do_req('post', url_template, url_args, body = json.dumps(payload))
  File "/usr/lib/python2.7/site-packages/pyarc/base.py", line 95, in _do_req_sync
    return self._do_req_base(method, url_template, url_args, query_args, body).get()
  File "/usr/lib/python2.7/site-packages/gremlin_rest/client.py", line 40, in get
    base_res = self.base_future.get()
  File "/usr/lib/python2.7/site-packages/gremlin_rest/client.py", line 16, in get
    base_res = self.base_future.get()
  File "/usr/lib/python2.7/site-packages/gremlin_rest/client.py", line 16, in get
    base_res = self.base_future.get()
  File "/usr/lib/python2.7/site-packages/pyarc/backends/requests_client.py", line 33, in get
    resp.text)
pyarc.base.RestException: An error has occurred during post to http://gremlin:8182/. Status 500. Body {"message":"Error encountered evaluating script: graph.V().count()"}
>>> client = GremlinClient('http://gremlin:8182', graph_variable="g")
>>> client.gremlin().V().count().run()
[368]
```